### PR TITLE
Quote column names to avoid conflict with psql identiifers

### DIFF
--- a/scripts/postgres/install.sql
+++ b/scripts/postgres/install.sql
@@ -1,5 +1,7 @@
 create or replace function journal.quote_column(name in varchar) returns varchar language plpgsql as $$
+begin
   return '"' || name || '"';
+end;
 $$;
 
 create or replace function journal.refresh_journal_trigger(
@@ -206,7 +208,7 @@ begin
     execute 'alter table ' || v_journal_name || ' add journal_timestamp timestamp with time zone not null default now() ';
     execute 'alter table ' || v_journal_name || ' add journal_operation text not null ';
     execute 'alter table ' || v_journal_name || ' add journal_id bigserial primary key ';
-    execute 'comment on table ' || v_journal_name || ' is ''Created by plsql function refresh_journaling to shadow all inserts, updates, and deletes on the table ' || p_source_schema_name || '.' || p_source_table_name || '''';
+    execute 'comment on table ' || v_journal_name || ' is ''Created by plsql function refresh_journaling to shadow all inserts, updates and deletes on the table ' || p_source_schema_name || '.' || p_source_table_name || '''';
     perform journal.add_primary_key_data(p_source_schema_name, p_source_table_name, p_target_schema_name, p_target_table_name);
   end if;
 

--- a/scripts/postgres/install.sql
+++ b/scripts/postgres/install.sql
@@ -206,7 +206,7 @@ begin
     execute 'alter table ' || v_journal_name || ' add journal_timestamp timestamp with time zone not null default now() ';
     execute 'alter table ' || v_journal_name || ' add journal_operation text not null ';
     execute 'alter table ' || v_journal_name || ' add journal_id bigserial primary key ';
-    execute 'comment on table ' || v_journal_name || ' is ''Created by plsql function refresh_journaling to shadow all inserts and updates on the table ' || p_source_schema_name || '.' || p_source_table_name || '''';
+    execute 'comment on table ' || v_journal_name || ' is ''Created by plsql function refresh_journaling to shadow all inserts, updates, and deletes on the table ' || p_source_schema_name || '.' || p_source_table_name || '''';
     perform journal.add_primary_key_data(p_source_schema_name, p_source_table_name, p_target_schema_name, p_target_table_name);
   end if;
 

--- a/scripts/postgres/install.sql
+++ b/scripts/postgres/install.sql
@@ -1,3 +1,7 @@
+create or replace function journal.quote_column(name in varchar) returns varchar language plpgsql as $$
+  return '"' || name || '"';
+$$;
+
 create or replace function journal.refresh_journal_trigger(
   p_source_schema_name in varchar,
   p_source_table_name in varchar,
@@ -37,8 +41,8 @@ begin
   v_target_sql = 'TG_OP';
 
   for row in (select column_name from information_schema.columns where table_schema = p_source_schema_name and table_name = p_source_table_name order by ordinal_position) loop
-    v_sql := v_sql || ', ' || row.column_name;
-    v_target_sql := v_target_sql || ', old.' || row.column_name;
+    v_sql := v_sql || ', ' || journal.quote_column(row.column_name);
+    v_target_sql := v_target_sql || ', old.' || journal.quote_column(row.column_name);
   end loop;
 
   v_sql := v_sql || ') values (' || v_target_sql || '); ';
@@ -89,8 +93,8 @@ begin
   v_target_sql = 'TG_OP';
 
   for row in (select column_name from information_schema.columns where table_schema = p_source_schema_name and table_name = p_source_table_name order by ordinal_position) loop
-    v_sql := v_sql || ', ' || row.column_name;
-    v_target_sql := v_target_sql || ', new.' || row.column_name;
+    v_sql := v_sql || ', ' || journal.quote_column(row.column_name);
+    v_target_sql := v_target_sql || ', new.' || journal.quote_column(row.column_name);
   end loop;
 
   v_sql := v_sql || ') values (' || v_target_sql || '); ';
@@ -191,9 +195,9 @@ begin
       -- columns anyway, so leaving it populated with null will be fine.
       select journal.get_data_type_string(information_schema.columns.*) into v_data_type from information_schema.columns where table_schema = p_target_schema_name and table_name = p_target_table_name and column_name = row.column_name;
       if not found then
-        execute 'alter table ' || v_journal_name || ' add ' || row.column_name || ' ' || row.data_type;
+        execute 'alter table ' || v_journal_name || ' add ' || journal.quote_column(row.column_name) || ' ' || row.data_type;
       elsif (row.data_type != v_data_type) then
-        execute 'alter table ' || v_journal_name || ' alter column ' || row.column_name || ' type ' || row.data_type;
+        execute 'alter table ' || v_journal_name || ' alter column ' || journal.quote_column(row.column_name) || ' type ' || row.data_type;
       end if;
 
     end loop;


### PR DESCRIPTION
If the column we are journaling contains columns which are keywords in
psql (e.g. 'primary'), then the command to create the journal trigger
will fail.

Example:

tmp=# create table tmp (id text primary key, "primary" boolean);
CREATE TABLE

tmp=# select journal.refresh_journaling('public', 'tmp', 'journal', 'tmp');

   ERROR:  syntax error at or near "primary"
   LINE 1: ...  insert into journal.tmp (journal_operation, id, primary) v...